### PR TITLE
Allow autoRename with arrays of objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,16 +13,16 @@ var blackList = {
 
 module.exports = function(obj, opts) {
   var result
-  if (isArray(obj)) result = createArray(obj)
+  if (isArray(obj)) result = createArray(obj, opts)
   else if (isObject(obj)) result = createObject(obj, opts)
   else result = value(obj)
   return result
 }
 
-function createArray(obj) {
+function createArray(obj, opts) {
   return array(obj.map(function(el) {
-    if (isArray(el)) return createArray(el)
-    if (isObject(el)) return createObject(el)
+    if (isArray(el)) return createArray(el, opts)
+    if (isObject(el)) return createObject(el, opts)
     return value(el)
   }))
 }

--- a/test.js
+++ b/test.js
@@ -117,6 +117,16 @@ test('rename blacklisted names', function(t){
   })
 
   t.equal(o2.duckname(), 'daffy')
+
+  var arrData = [
+    {"name":"batman"}
+  ]
+
+  var o3 = observify(arrData, {
+    autoRename:true
+  })
+
+  t.equal(o3.get(0).$name(), 'batman')
   t.end()
 })
 


### PR DESCRIPTION
This prevents `name` clashes when using arrays.